### PR TITLE
Error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,12 +38,12 @@ export function createHandler (functions) {
   return function handler (self) {
     const cache = {}
 
-    self.addEventListener('message', function (event) {
+    self.addEventListener('message', async function (event) {
       const {command, id, message} = event.data
 
       let results
       try {
-        results = functions[command].call(null, cache, message)
+        results = await functions[command].call(null, cache, message)
       } catch (error) {
         // nonstandard but will just be undefined on browsers that don't support
         const { fileName, lineNumber } = error
@@ -56,6 +56,8 @@ export function createHandler (functions) {
             message: error.message
           }
         })
+
+        return
       }
 
       self.postMessage({

--- a/index.js
+++ b/index.js
@@ -41,9 +41,13 @@ export function createHandler (functions) {
     self.addEventListener('message', async function (event) {
       const {command, id, message} = event.data
 
-      let results
       try {
-        results = await functions[command].call(null, cache, message)
+        const results = await functions[command].call(null, cache, message)
+        self.postMessage({
+          command,
+          id,
+          message: results
+        })
       } catch (error) {
         // nonstandard but will just be undefined on browsers that don't support
         const { fileName, lineNumber } = error
@@ -56,15 +60,7 @@ export function createHandler (functions) {
             message: error.message
           }
         })
-
-        return
       }
-
-      self.postMessage({
-        command,
-        id,
-        message: results
-      })
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Class interface for Promisfying WebWorker handling",
   "main": "./build/index",
   "scripts": {
-    "prepublish": "mastarm prepublish index.js",
+    "prepublish": "mastarm prepublish index.js:build/index.js",
     "test": "mastarm lint",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },


### PR DESCRIPTION
The current implementation attempts to add an ID to the error object, but error objects are not transferable, rather an ErrorEvent object is created (which does not contain the ID) and that is used to call the `onerror` handler. This implements custom error handling so that we can associate an ID with an error and reject the correct promise when needed.